### PR TITLE
docs: extend the verified harness range to 0.1.0-rc.7

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -24,7 +24,7 @@
 
 | Surface | Status |
 |---|---|
-| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.6` |
+| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.7` |
 | Node | `^22.19.0 || >=24.0.0` |
 | Platforms | Todas (host + cliente web de settings) |
 | Model | Cualquiera (las razones deny/ask se muestran a través de los resultados de herramienta) |

--- a/README.hi.md
+++ b/README.hi.md
@@ -24,7 +24,7 @@
 
 | Surface | Status |
 |---|---|
-| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.6` |
+| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.7` |
 | Node | `^22.19.0 || >=24.0.0` |
 | Platforms | सभी (host + वेब settings क्लाइंट) |
 | Model | कोई भी (deny/ask कारण टूल परिणामों के माध्यम से दिखते हैं) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 | Surface | Status |
 |---|---|
-| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.6` |
+| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.7` |
 | Node | `^22.19.0 || >=24.0.0` |
 | Platforms | All (host + web settings client) |
 | Model | Any (deny/ask reasons surface through tool results) |

--- a/README.pt.md
+++ b/README.pt.md
@@ -24,7 +24,7 @@
 
 | Surface | Status |
 |---|---|
-| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.6` |
+| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.7` |
 | Node | `^22.19.0 || >=24.0.0` |
 | Platforms | Todas (host + cliente web de settings) |
 | Model | Qualquer (razões deny/ask aparecem pelos resultados de ferramenta) |

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,7 +24,7 @@
 
 | Surface | Status |
 |---|---|
-| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.6` |
+| Harness | DeepSeek Harness `0.1.0-rc.5`–`0.1.0-rc.7` |
 | Node | `^22.19.0 || >=24.0.0` |
 | Platforms | 全部（host + Web 设置客户端） |
 | Model | 任意（deny/ask 原因经工具结果呈现） |


### PR DESCRIPTION
## What

Extends the README compatibility table from `0.1.0-rc.5`–`0.1.0-rc.6` to `0.1.0-rc.5`–**`0.1.0-rc.7`**, in all five language READMEs. Docs only — no code touched.

## Why

rc.7 is the current npm `latest` for `@deepseek-ai/dsh`. I hit the table while deciding whether to adopt this plugin, assumed it wouldn't work, then tried it anyway — it works.

## How it was verified

Isolated profile (`base` + `headless` + this plugin), skills and global instructions switched off so the probe measures the gate and nothing else.

`.dsh/rules.yaml`:

```yaml
rules:
  - match: { tools: [bash], params: { command: "*CANARY*" } }
    action: deny
    reason: "canary rule: rc.7 compat probe"
```

Same prompt, run twice — `Run the shell command: echo CANARY_TEST_123 — then report its exact stdout.`

| | rules file moved aside | rules file in place |
|---|---|---|
| result | command runs, stdout `CANARY_TEST_123` | blocked |
| model sees | normal tool result | `Error: canary rule: rc.7 compat probe` |

Audit event from the session log on the blocked run:

```json
{"type":"permissionRules/decision","data":{"toolName":"bash","action":"deny",
 "outcome":"deny","ruleIndex":0,"reason":"canary rule: rc.7 compat probe",
 "source":".../.dsh/rules.yaml"}}
```

Environment: dsh `0.1.0-rc.7` · `dsh-permission-rules@0.5.2` · Node v26.4.0 · macOS 27.0 arm64.

## What this PR does *not* claim

Only the deny path was exercised on rc.7. Untested here: the `ask` / approval seam, network policy, `mcp__*` tool matching, and the web settings client. If you would rather the table track only what CI covers, say so and I'll narrow the upper bound or add a "verified" footnote instead.
